### PR TITLE
Add config() method to parse the output of `task _show`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { Task } from '../types';
+import { Task, TaskRc, TaskRcItem } from '../types';
 
 export class TaskError extends Error {
 }
@@ -62,6 +62,34 @@ export class TaskwarriorLib {
 		if (result && result.charAt(0) !== 'P') {
 			throw new TaskError(`Invalid period string '${period}'`);
 		}
+	}
+
+	/**
+	 * Parse TaskWarrior configuration.
+	 */
+	config() {
+		const result = this.executeCommand("_show");
+		const config: TaskRc = {};
+		if (result) {
+			for (const line of result.split('\n')) {
+				var separator = line.indexOf("=");
+				const [key, value] = [
+					line.substr(0, separator),
+					line.substr( separator + 1)
+				];
+				const path = key.split(".");
+				let obj = config;
+				for (let i = 0; i < path.length - 1; ++i) {
+					const objKey = path[i] + '.';
+					if (!obj[objKey]) {
+						obj[objKey] = {};
+					}
+					obj = obj[objKey] as TaskRc;
+				}
+				obj[path[path.length - 1]] = value;
+			}
+		}
+		return config;
 	}
 
 	/**

--- a/test/test.ts
+++ b/test/test.ts
@@ -6,6 +6,9 @@ const taskwarrior = new TaskwarriorLib(
 	path.join(__dirname, '.task')
 );
 
+const config = taskwarrior.config();
+console.log(config);
+
 // Add tasks
 const newTasks = new Array(16);
 newTasks.fill({

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,11 @@ export declare class TaskwarriorLib {
 	calc(expression?: string): string | undefined;
 
 	/**
+	 * Parse TaskWarrior configuration.
+	 */
+	config() : TaskRc;
+
+	/**
 	 * Load from taskwarrior
 	 */
 	load(filters?: string): Task[];
@@ -42,6 +47,10 @@ export declare class TaskwarriorLib {
 
 export declare class TaskError extends Error {
 }
+
+export type TaskRc = { [key: string]: TaskRcItem };
+
+export type TaskRcItem = {[key: string] : TaskRcItem} | string;
 
 export declare type TaskStatus = 'pending' | 'waiting' | 'deleted' | 'completed' | 'recurring'
 


### PR DESCRIPTION
This allows parsing the configuration values from `.taskrc` including contexts and reports.